### PR TITLE
Add player data contract definitions

### DIFF
--- a/Flowcast.Server/GameServer/GameServer.sln
+++ b/Flowcast.Server/GameServer/GameServer.sln
@@ -21,6 +21,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shared.API", "BuildingBlock
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Modules", "Modules", "{287EC64B-9984-4D58-B1FD-BA8040A21F9A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PlayerData", "PlayerData", "{5D8F7FD8-96F2-4BD7-BFDB-0DC4B94F8267}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Identity.API", "Modules\Identity\Identity.API\Identity.API.csproj", "{0381A6DE-0E79-BA74-463B-19D069306550}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Identity.Contracts", "Modules\Identity\Identity.Contracts\Identity.Contracts.csproj", "{46A441BC-A83C-8E23-AC2A-C0830C7234D1}"
@@ -54,6 +56,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Matchmaking.Application", "Modules\Matchmaking\Matchmaking.Application\Matchmaking.Application.csproj", "{7694681B-5352-FE04-E47E-375C796B7BB0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Matchmaking.Presentation", "Modules\Matchmaking\Matchmaking.Presentation\Matchmaking.Presentation.csproj", "{3F700388-8417-467D-8555-ADBF9A045F12}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PlayerData.Contracts", "Modules\PlayerData\PlayerData.Contracts\PlayerData.Contracts.csproj", "{CFF717AA-DCFC-4EA3-92C6-4BF2ABCA87AD}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shared.Infrastructure", "BuildingBlocks\Shared.Infrastructure\Shared.Infrastructure.csproj", "{3DD7618E-2867-44B0-8E7C-FE1C3EA6CE50}"
 EndProject
@@ -139,14 +143,18 @@ Global
 		{7694681B-5352-FE04-E47E-375C796B7BB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7694681B-5352-FE04-E47E-375C796B7BB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7694681B-5352-FE04-E47E-375C796B7BB0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3F700388-8417-467D-8555-ADBF9A045F12}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3F700388-8417-467D-8555-ADBF9A045F12}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3F700388-8417-467D-8555-ADBF9A045F12}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3F700388-8417-467D-8555-ADBF9A045F12}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3DD7618E-2867-44B0-8E7C-FE1C3EA6CE50}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3DD7618E-2867-44B0-8E7C-FE1C3EA6CE50}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3DD7618E-2867-44B0-8E7C-FE1C3EA6CE50}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3DD7618E-2867-44B0-8E7C-FE1C3EA6CE50}.Release|Any CPU.Build.0 = Release|Any CPU
+                {3F700388-8417-467D-8555-ADBF9A045F12}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {3F700388-8417-467D-8555-ADBF9A045F12}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {3F700388-8417-467D-8555-ADBF9A045F12}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {3F700388-8417-467D-8555-ADBF9A045F12}.Release|Any CPU.Build.0 = Release|Any CPU
+                {CFF717AA-DCFC-4EA3-92C6-4BF2ABCA87AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {CFF717AA-DCFC-4EA3-92C6-4BF2ABCA87AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {CFF717AA-DCFC-4EA3-92C6-4BF2ABCA87AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {CFF717AA-DCFC-4EA3-92C6-4BF2ABCA87AD}.Release|Any CPU.Build.0 = Release|Any CPU
+                {3DD7618E-2867-44B0-8E7C-FE1C3EA6CE50}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {3DD7618E-2867-44B0-8E7C-FE1C3EA6CE50}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {3DD7618E-2867-44B0-8E7C-FE1C3EA6CE50}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {3DD7618E-2867-44B0-8E7C-FE1C3EA6CE50}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -173,8 +181,10 @@ Global
 		{275FE2A5-28A8-4FA0-83E5-D5FF95F3A714} = {91D36881-9133-4018-9262-D0D160C98F63}
 		{FC9377F3-AAC1-4F7C-AFD8-C2EEF8B59FFE} = {91D36881-9133-4018-9262-D0D160C98F63}
 		{7694681B-5352-FE04-E47E-375C796B7BB0} = {BAC7E37B-A524-4EEA-A6BD-03A709AED4DA}
-		{3F700388-8417-467D-8555-ADBF9A045F12} = {BAC7E37B-A524-4EEA-A6BD-03A709AED4DA}
-		{3DD7618E-2867-44B0-8E7C-FE1C3EA6CE50} = {52BF9116-0C91-4AF0-BABF-3FCC8E107D6E}
+                {3F700388-8417-467D-8555-ADBF9A045F12} = {BAC7E37B-A524-4EEA-A6BD-03A709AED4DA}
+                {5D8F7FD8-96F2-4BD7-BFDB-0DC4B94F8267} = {287EC64B-9984-4D58-B1FD-BA8040A21F9A}
+                {CFF717AA-DCFC-4EA3-92C6-4BF2ABCA87AD} = {5D8F7FD8-96F2-4BD7-BFDB-0DC4B94F8267}
+                {3DD7618E-2867-44B0-8E7C-FE1C3EA6CE50} = {52BF9116-0C91-4AF0-BABF-3FCC8E107D6E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BD7E6969-6F51-4BB6-BB12-8FE6C3398EC9}

--- a/Flowcast.Server/GameServer/Modules/PlayerData/PlayerData.Contracts/PlayerData.Contracts.csproj
+++ b/Flowcast.Server/GameServer/Modules/PlayerData/PlayerData.Contracts/PlayerData.Contracts.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Flowcast.Server/GameServer/Modules/PlayerData/PlayerData.Contracts/V1/LoadProfile.cs
+++ b/Flowcast.Server/GameServer/Modules/PlayerData/PlayerData.Contracts/V1/LoadProfile.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using PlayerData.Contracts.V1.Shared;
+
+namespace PlayerData.Contracts.V1;
+
+public static class LoadProfile
+{
+    public const string Method = "GET";
+    public const string Route = "player-data/profile/{playerId:guid}";
+
+    public const string Summary = "Load player profile data";
+    public const string Description = "Returns the namespaces stored for a player profile. Optionally filter by namespace name.";
+
+    public record Request(
+        Guid PlayerId,
+        IReadOnlyCollection<string>? Namespaces = null
+    );
+
+    public record Response(
+        Guid PlayerId,
+        NamespaceDocument[] Namespaces
+    );
+}

--- a/Flowcast.Server/GameServer/Modules/PlayerData/PlayerData.Contracts/V1/LoadProfile.cs
+++ b/Flowcast.Server/GameServer/Modules/PlayerData/PlayerData.Contracts/V1/LoadProfile.cs
@@ -7,7 +7,7 @@ namespace PlayerData.Contracts.V1;
 public static class LoadProfile
 {
     public const string Method = "GET";
-    public const string Route = "player-data/profile/{playerId:guid}";
+    public const string Route = "player-data/profile";
 
     public const string Summary = "Load player profile data";
     public const string Description = "Returns the namespaces stored for a player profile. Optionally filter by namespace name.";

--- a/Flowcast.Server/GameServer/Modules/PlayerData/PlayerData.Contracts/V1/SaveProfile.cs
+++ b/Flowcast.Server/GameServer/Modules/PlayerData/PlayerData.Contracts/V1/SaveProfile.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using PlayerData.Contracts.V1.Shared;
+
+namespace PlayerData.Contracts.V1;
+
+public static class SaveProfile
+{
+    public const string Method = "POST";
+    public const string Route = "player-data/profile";
+
+    public const string Summary = "Save player profile data";
+    public const string Description = "Creates or replaces namespaces for a player profile.";
+
+    public record Request(
+        Guid PlayerId,
+        IReadOnlyCollection<NamespaceWrite> Namespaces
+    );
+
+    public record Response(
+        Guid PlayerId,
+        NamespaceDocument[] Namespaces
+    );
+}

--- a/Flowcast.Server/GameServer/Modules/PlayerData/PlayerData.Contracts/V1/Shared/NamespaceDocument.cs
+++ b/Flowcast.Server/GameServer/Modules/PlayerData/PlayerData.Contracts/V1/Shared/NamespaceDocument.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Text.Json;
+
+namespace PlayerData.Contracts.V1.Shared;
+
+public record NamespaceDocument(
+    string Namespace,
+    JsonElement Document,
+    string? Version = null,
+    DateTimeOffset? UpdatedAtUtc = null
+);

--- a/Flowcast.Server/GameServer/Modules/PlayerData/PlayerData.Contracts/V1/Shared/NamespaceWrite.cs
+++ b/Flowcast.Server/GameServer/Modules/PlayerData/PlayerData.Contracts/V1/Shared/NamespaceWrite.cs
@@ -1,0 +1,9 @@
+using System.Text.Json;
+
+namespace PlayerData.Contracts.V1.Shared;
+
+public record NamespaceWrite(
+    string Namespace,
+    JsonElement Document,
+    string? ClientVersion = null
+);


### PR DESCRIPTION
## Summary
- add a PlayerData.Contracts project for the new module
- define V1 LoadProfile and SaveProfile contracts with shared namespace payload records
- register the project in the solution under a dedicated PlayerData folder

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e100c276a8832fb55c6e7e1a4cee7d