### PR TITLE
Switch PlayerProgressStore contracts to JsonElement documents

### DIFF
--- a/Flowcast.Server/GameServer/Modules/PlayerProgressStore/PlayerProgressStore.Contracts/V1/Shared/NamespaceDocument.cs
+++ b/Flowcast.Server/GameServer/Modules/PlayerProgressStore/PlayerProgressStore.Contracts/V1/Shared/NamespaceDocument.cs
@@ -13,7 +13,7 @@ namespace PlayerProgressStore.Contracts.V1.Shared;
 /// <param name="UpdatedAtUtc">Last update timestamp in UTC.</param>
 public readonly record struct NamespaceDocument(
     string Namespace,
-    string Document,
+    JsonElement Document,
     string Version,
     long Progress,
     string Hash,

--- a/Flowcast.Server/GameServer/Modules/PlayerProgressStore/PlayerProgressStore.Contracts/V1/Shared/NamespaceWrite.cs
+++ b/Flowcast.Server/GameServer/Modules/PlayerProgressStore/PlayerProgressStore.Contracts/V1/Shared/NamespaceWrite.cs
@@ -17,7 +17,7 @@ namespace PlayerProgressStore.Contracts.V1.Shared;
 /// </param>
 public readonly record struct NamespaceWrite(
     string Namespace,
-    string Document,
+    JsonElement Document,
     long Progress,
     string? ClientVersion = null,
     string? ClientHash = null

--- a/Flowcast.Server/GameServer/Modules/PlayerProgressStore/PlayerProgressStore.Presentation/Endpoints/V1/LoadProfileEndpoint.cs
+++ b/Flowcast.Server/GameServer/Modules/PlayerProgressStore/PlayerProgressStore.Presentation/Endpoints/V1/LoadProfileEndpoint.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using System.Text.Json;
 using PlayerProgressStore.Application.Queries;
 using PlayerProgressStore.Contracts;
 using PlayerProgressStore.Contracts.V1;
@@ -51,7 +52,7 @@ public sealed class LoadProfileEndpoint : IEndpoint
         var docs = playerNamespaces
             .Select(x => new NamespaceDocument(
                 x.Namespace,
-                x.Document,
+                ParseDocument(x.Document),
                 x.Version.Value,
                 x.Progress.Value,
                 x.Hash.Value,
@@ -60,4 +61,17 @@ public sealed class LoadProfileEndpoint : IEndpoint
 
         return new LoadProfile.Response(docs);
     }
+
+    private static JsonElement ParseDocument(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            using var empty = JsonDocument.Parse("{}");
+            return empty.RootElement.Clone();
+        }
+
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
+    }
+
 }

--- a/Flowcast.Server/GameServer/Modules/PlayerProgressStore/PlayerProgressStore.Presentation/Endpoints/V1/SaveProfileEndpoint.cs
+++ b/Flowcast.Server/GameServer/Modules/PlayerProgressStore/PlayerProgressStore.Presentation/Endpoints/V1/SaveProfileEndpoint.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using System.Text.Json;
 using PlayerProgressStore.Application.Commands;
 using PlayerProgressStore.Contracts;
 using PlayerProgressStore.Contracts.V1;
@@ -60,7 +61,7 @@ public sealed class SaveProfileEndpoint : IEndpoint
         var docs = playerNamespaces
             .Select(x => new NamespaceDocument(
                 x.Namespace,
-                x.Document,
+                ParseDocument(x.Document),
                 x.Version.Value,
                 x.Progress.Value,
                 x.Hash.Value,
@@ -69,4 +70,17 @@ public sealed class SaveProfileEndpoint : IEndpoint
 
         return new SaveProfile.Response(docs);
     }
+
+    private static JsonElement ParseDocument(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            using var empty = JsonDocument.Parse("{}");
+            return empty.RootElement.Clone();
+        }
+
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
+    }
+
 }


### PR DESCRIPTION
## Summary
- change the PlayerProgressStore contracts so namespace documents are represented as JsonElement instead of raw strings
- update the save command pipeline to canonicalize and hash JsonElement inputs while preserving existing fallbacks
- ensure the presentation layer converts stored canonical JSON back into JsonElement responses for load/save endpoints

## Testing
- dotnet build GameServer.sln *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f771eb8568832f85a42469f00f6cc5