### PR TITLE
Add endpoints for byte-array player progress data

### DIFF
--- a/Flowcast.Server/GameServer/Modules/PlayerProgressStore/PlayerProgressStore.Contracts/V1/LoadProfileBytes.cs
+++ b/Flowcast.Server/GameServer/Modules/PlayerProgressStore/PlayerProgressStore.Contracts/V1/LoadProfileBytes.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Mvc;
+using PlayerProgressStore.Contracts.V1.Shared;
+
+namespace PlayerProgressStore.Contracts.V1;
+
+/// <summary>
+/// Load player progress profile (selected namespaces or all) with payloads encoded as byte arrays.
+/// </summary>
+public static class LoadProfileBytes
+{
+    public const string Method = "GET";
+    public const string Route = "player-progress/profile/bytes";
+    public const string Summary = "Load player progress data as byte arrays";
+    public const string Description =
+        "Returns the namespaces stored for a player profile encoded as byte arrays. Optionally filter by namespace name.";
+
+    /// <summary>
+    /// If <see cref="Namespaces"/> is null or empty, the server may return all existing namespaces for the player.
+    /// </summary>
+    /// <param name="Namespaces">Subset of namespaces to load (e.g., [\"playerStats\",\"inventory\"]).</param>
+    public sealed record Request
+    {
+        [FromQuery(Name = "namespaces")]
+        public string[]? Namespaces { get; init; }
+    }
+
+    /// <summary>
+    /// Authoritative response with one or more namespaces represented as byte arrays.
+    /// </summary>
+    /// <param name="Namespaces">Returned namespace documents.</param>
+    public sealed record Response(
+        NamespaceBinaryDocument[] Namespaces
+    );
+}

--- a/Flowcast.Server/GameServer/Modules/PlayerProgressStore/PlayerProgressStore.Contracts/V1/SaveProfileBytes.cs
+++ b/Flowcast.Server/GameServer/Modules/PlayerProgressStore/PlayerProgressStore.Contracts/V1/SaveProfileBytes.cs
@@ -1,0 +1,32 @@
+using PlayerProgressStore.Contracts.V1.Shared;
+
+namespace PlayerProgressStore.Contracts.V1;
+
+/// <summary>
+/// Atomic batch save for one or more namespaces represented as byte arrays.
+/// </summary>
+public static class SaveProfileBytes
+{
+    public const string Method = "POST";
+    public const string Route = "player-progress/profile/bytes";
+    public const string Summary = "Save player progress data (atomic, byte arrays)";
+    public const string Description =
+        "Creates or replaces namespaces for a player profile atomically using byte array payloads. " +
+        "Server enforces progress-first conflict handling and returns authoritative copies.";
+
+    /// <summary>
+    /// Batch of namespace writes to apply atomically.
+    /// </summary>
+    /// <param name="Namespaces">One or more namespace writes.</param>
+    public sealed record Request(
+        IReadOnlyCollection<NamespaceBinaryWrite> Namespaces
+    );
+
+    /// <summary>
+    /// Authoritative result after the atomic save is committed.
+    /// </summary>
+    /// <param name="Namespaces">Committed namespace documents (server truth).</param>
+    public sealed record Response(
+        NamespaceBinaryDocument[] Namespaces
+    );
+}

--- a/Flowcast.Server/GameServer/Modules/PlayerProgressStore/PlayerProgressStore.Contracts/V1/Shared/NamespaceBinaryDocument.cs
+++ b/Flowcast.Server/GameServer/Modules/PlayerProgressStore/PlayerProgressStore.Contracts/V1/Shared/NamespaceBinaryDocument.cs
@@ -1,0 +1,19 @@
+namespace PlayerProgressStore.Contracts.V1.Shared;
+
+/// <summary>
+/// Server → Client document for a namespace represented as raw UTF-8 bytes.
+/// </summary>
+/// <param name="Namespace">Namespace name.</param>
+/// <param name="Document">Authoritative document payload encoded as UTF-8 byte array.</param>
+/// <param name="Version">Server-owned version token (etag-like, monotonic/opaque).</param>
+/// <param name="Progress">Authoritative progress value.</param>
+/// <param name="Hash">Server-computed SHA-256 (canonical JSON) e.g., "sha256:abcd...".</param>
+/// <param name="UpdatedAtUtc">Last update timestamp in UTC.</param>
+public readonly record struct NamespaceBinaryDocument(
+    string Namespace,
+    byte[] Document,
+    string Version,
+    long Progress,
+    string Hash,
+    DateTimeOffset UpdatedAtUtc
+);

--- a/Flowcast.Server/GameServer/Modules/PlayerProgressStore/PlayerProgressStore.Contracts/V1/Shared/NamespaceBinaryWrite.cs
+++ b/Flowcast.Server/GameServer/Modules/PlayerProgressStore/PlayerProgressStore.Contracts/V1/Shared/NamespaceBinaryWrite.cs
@@ -1,0 +1,22 @@
+namespace PlayerProgressStore.Contracts.V1.Shared;
+
+/// <summary>
+/// Client → Server write model for a single namespace represented as raw UTF-8 bytes.
+/// </summary>
+/// <param name="Namespace">Logical document bucket (e.g., "playerStats", "inventory", or "global").</param>
+/// <param name="Document">The client document payload encoded as UTF-8 byte array.</param>
+/// <param name="Progress">Semantic gameplay progress metric used for conflict resolution.</param>
+/// <param name="ClientVersion">
+/// The last server version the client saw for this namespace (sync anchor).
+/// If null/missing, treated as "v0".
+/// </param>
+/// <param name="ClientHash">
+/// Optional hint for no-op/dedupe. The server should not trust this for conflict decisions.
+/// </param>
+public readonly record struct NamespaceBinaryWrite(
+    string Namespace,
+    byte[]? Document,
+    long Progress,
+    string? ClientVersion = null,
+    string? ClientHash = null
+);

--- a/Flowcast.Server/GameServer/Modules/PlayerProgressStore/PlayerProgressStore.Presentation/Endpoints/V1/LoadProfileBytesEndpoint.cs
+++ b/Flowcast.Server/GameServer/Modules/PlayerProgressStore/PlayerProgressStore.Presentation/Endpoints/V1/LoadProfileBytesEndpoint.cs
@@ -1,0 +1,74 @@
+using System.Text;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using PlayerProgressStore.Application.Queries;
+using PlayerProgressStore.Contracts;
+using PlayerProgressStore.Contracts.V1;
+using PlayerProgressStore.Contracts.V1.Shared;
+using PlayerProgressStore.Domain;
+using Shared.Application.Authentication;
+using Shared.Application.Messaging;
+using Shared.Presentation.Endpoints;
+using SharedKernel;
+
+namespace PlayerProgressStore.Presentation.Endpoints.V1;
+
+public sealed class LoadProfileBytesEndpoint : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet(LoadProfileBytes.Route,
+            async ([AsParameters] LoadProfileBytes.Request request,
+                   [FromServices] IQueryHandler<LoadProfileQuery, PlayerNamespace[]> handler,
+                   [FromServices] IUserContext userContext,
+                   HttpContext httpContext,
+                   CancellationToken ct) =>
+        {
+            var query = ToQuery(request, userContext.UserId);
+
+            var result = await handler.Handle(query, ct);
+
+            return result.Match(
+                _ => Results.Ok(ToResponse(result.Value)),
+                error => CustomResults.Problem(error, httpContext)
+            );
+        })
+        .RequireAuthorization()
+        .WithTags(ApiInfo.Tag)
+        .WithSummary(LoadProfileBytes.Summary)
+        .WithDescription(LoadProfileBytes.Description)
+        .MapToApiVersion(1.0);
+    }
+
+    private static LoadProfileQuery ToQuery(LoadProfileBytes.Request request, string userId)
+    {
+        return new LoadProfileQuery(userId, request.Namespaces);
+    }
+
+    private static LoadProfileBytes.Response ToResponse(PlayerNamespace[] playerNamespaces)
+    {
+        var docs = playerNamespaces
+            .Select(x => new NamespaceBinaryDocument(
+                x.Namespace,
+                ToBytes(x.Document),
+                x.Version.Value,
+                x.Progress.Value,
+                x.Hash.Value,
+                x.UpdatedAtUtc))
+            .ToArray();
+
+        return new LoadProfileBytes.Response(docs);
+    }
+
+    private static byte[] ToBytes(string document)
+    {
+        if (string.IsNullOrEmpty(document))
+        {
+            return Array.Empty<byte>();
+        }
+
+        return Encoding.UTF8.GetBytes(document);
+    }
+}

--- a/Flowcast.Server/GameServer/Modules/PlayerProgressStore/PlayerProgressStore.Presentation/Endpoints/V1/SaveProfileBytesEndpoint.cs
+++ b/Flowcast.Server/GameServer/Modules/PlayerProgressStore/PlayerProgressStore.Presentation/Endpoints/V1/SaveProfileBytesEndpoint.cs
@@ -1,0 +1,96 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using PlayerProgressStore.Application.Commands;
+using PlayerProgressStore.Contracts;
+using PlayerProgressStore.Contracts.V1;
+using PlayerProgressStore.Contracts.V1.Shared;
+using PlayerProgressStore.Domain;
+using Shared.Application.Authentication;
+using Shared.Application.Messaging;
+using Shared.Presentation.Endpoints;
+using SharedKernel;
+
+namespace PlayerProgressStore.Presentation.Endpoints.V1;
+
+public sealed class SaveProfileBytesEndpoint : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPost(SaveProfileBytes.Route,
+            async ([FromBody] SaveProfileBytes.Request request,
+                   [FromServices] ICommandHandler<SaveProfileCommand, PlayerNamespace[]> handler,
+                   [FromServices] IUserContext userContext,
+                   HttpContext httpContext,
+                   CancellationToken ct) =>
+            {
+                var command = ToCommand(request, userContext.UserId);
+
+                var result = await handler.Handle(command, ct);
+
+                return result.Match(
+                    _ => Results.Ok(ToResponse(result.Value)),
+                    error => CustomResults.Problem(error, httpContext)
+                );
+            })
+        .RequireAuthorization()
+        .WithTags(ApiInfo.Tag)
+        .WithSummary(SaveProfileBytes.Summary)
+        .WithDescription(SaveProfileBytes.Description)
+        .MapToApiVersion(1.0);
+    }
+
+    private static SaveProfileCommand ToCommand(SaveProfileBytes.Request request, string userId)
+    {
+        var dto = request.Namespaces
+            .Select(x => new NamespaceWriteDto(
+                x.Namespace,
+                ParseDocument(x.Document),
+                x.Progress,
+                x.ClientVersion,
+                x.ClientHash))
+            .ToArray();
+
+        return new SaveProfileCommand(userId, dto);
+    }
+
+    private static SaveProfileBytes.Response ToResponse(PlayerNamespace[] playerNamespaces)
+    {
+        var docs = playerNamespaces
+            .Select(x => new NamespaceBinaryDocument(
+                x.Namespace,
+                ToBytes(x.Document),
+                x.Version.Value,
+                x.Progress.Value,
+                x.Hash.Value,
+                x.UpdatedAtUtc))
+            .ToArray();
+
+        return new SaveProfileBytes.Response(docs);
+    }
+
+    private static JsonElement ParseDocument(byte[]? document)
+    {
+        if (document is null || document.Length == 0)
+        {
+            using var empty = JsonDocument.Parse("{}");
+            return empty.RootElement.Clone();
+        }
+
+        using var doc = JsonDocument.Parse(document);
+        return doc.RootElement.Clone();
+    }
+
+    private static byte[] ToBytes(string document)
+    {
+        if (string.IsNullOrEmpty(document))
+        {
+            return Array.Empty<byte>();
+        }
+
+        return Encoding.UTF8.GetBytes(document);
+    }
+}


### PR DESCRIPTION
## Summary
- add API contracts for byte-array load and save operations in the player progress module
- expose new endpoints that translate between stored JSON documents and byte payloads while reusing existing handlers

## Testing
- not run (dotnet CLI unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f911d71898832f95e70e63960496b4