### PR TITLE
Improve REST tooling stability and serializer support

### DIFF
--- a/Flowcast.Unity/Assets/Flowcast/Editor/Core/Environments/EnvironmentSwitcherWindow.cs
+++ b/Flowcast.Unity/Assets/Flowcast/Editor/Core/Environments/EnvironmentSwitcherWindow.cs
@@ -17,6 +17,23 @@ namespace Flowcast.Core.Environments.Editor
         private void OnEnable()
         {
             _settings = FlowcastClientSettings.LoadFromResources();
+            EnvironmentProvider.Instance.Changed += OnEnvironmentChanged;
+        }
+
+        private void OnDisable()
+        {
+            EnvironmentProvider.Instance.Changed -= OnEnvironmentChanged;
+        }
+
+        private void OnFocus()
+        {
+            _settings = FlowcastClientSettings.LoadFromResources();
+            Repaint();
+        }
+
+        private void OnEnvironmentChanged(Flowcast.Core.Environments.Environment _)
+        {
+            Repaint();
         }
 
         private void OnGUI()

--- a/Flowcast.Unity/Assets/Flowcast/Runtime/Rest/Pipeline/CacheBehavior.cs
+++ b/Flowcast.Unity/Assets/Flowcast/Runtime/Rest/Pipeline/CacheBehavior.cs
@@ -113,7 +113,18 @@ namespace Flowcast.Rest.Pipeline
                     ApplyCachingHeaders(key, resp); // renew TTL from headers
             }
             catch { /* swallow */ }
-            finally { gate.Release(); }
+            finally
+            {
+                gate.Release();
+                if (_revalGates.TryRemove(key, out var removed))
+                {
+                    removed.Dispose();
+                }
+                else
+                {
+                    gate.Dispose();
+                }
+            }
         }
 
         private void Store(string key, ApiResponse resp)


### PR DESCRIPTION
## Summary
- add policy controls to the REST Workbench so ad-hoc requests can toggle features without requiring a saved asset
- resolve response deserializers through the registered serializer registry and fall back to Accept preferences or JSON defaults
- clean up cache revalidation gates, make the memory cache thread-safe, and refresh the environment switcher when environments change

## Testing
- not run (Unity project)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910ac4f5d18832da457471ed5a77d36)