### PR TITLE
Adjust environment configuration logic and dependency references

### DIFF
--- a/Flowcast.Unity/Assets/Flowcast/Runtime/Rest/Flowcast.Rest.asmdef
+++ b/Flowcast.Unity/Assets/Flowcast/Runtime/Rest/Flowcast.Rest.asmdef
@@ -2,8 +2,7 @@
     "name": "Flowcast.Rest",
     "rootNamespace": "",
     "references": [
-        "Flowcast.Core",
-        "UniTask"
+        "Flowcast.Core"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
## Summary
- update FlowcastRestSettings to pick the active environment based on editor, development, or release context and expose stored RequestAsset references
- adapt EnvironmentProvider and the package initializer window to respect the new environment selection flow and configure asmdef dependencies dynamically
- drop the static UniTask reference from Flowcast.Rest so optional packages are wired only when present

## Testing
- not run (Unity editor tooling)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910c3cb00c8832d930854b398849438)