### PR TITLE
Add environment and request scaffolding to Flowcast initializer

### DIFF
--- a/Flowcast.Unity/Assets/Flowcast/Runtime/Rest/Bootstrap/FlowcastRestSettings.cs
+++ b/Flowcast.Unity/Assets/Flowcast/Runtime/Rest/Bootstrap/FlowcastRestSettings.cs
@@ -86,6 +86,43 @@ namespace Flowcast.Rest.Bootstrap
 
         public IReadOnlyList<RequestAsset> RequestAssets => requestAssets;
 
+        public bool TryGetRequestAsset(string nameOrId, out RequestAsset asset)
+        {
+            if (!string.IsNullOrEmpty(nameOrId))
+            {
+                foreach (var request in requestAssets)
+                {
+                    if (request == null)
+                    {
+                        continue;
+                    }
+
+                    if (!string.IsNullOrEmpty(request.RequestId) &&
+                        string.Equals(request.RequestId, nameOrId, StringComparison.OrdinalIgnoreCase))
+                    {
+                        asset = request;
+                        return true;
+                    }
+
+                    if (!string.IsNullOrEmpty(request.DisplayName) &&
+                        string.Equals(request.DisplayName, nameOrId, StringComparison.OrdinalIgnoreCase))
+                    {
+                        asset = request;
+                        return true;
+                    }
+
+                    if (string.Equals(request.name, nameOrId, StringComparison.OrdinalIgnoreCase))
+                    {
+                        asset = request;
+                        return true;
+                    }
+                }
+            }
+
+            asset = null;
+            return false;
+        }
+
         public bool TryGetById(string id, out Environment env)
         {
             if (!string.IsNullOrEmpty(id))

--- a/Flowcast.Unity/Assets/Flowcast/Runtime/Rest/Workbench/RequestAsset.cs
+++ b/Flowcast.Unity/Assets/Flowcast/Runtime/Rest/Workbench/RequestAsset.cs
@@ -11,6 +11,13 @@ namespace Flowcast.Rest.Workbench
     {
         public enum MethodKind { GET, POST, PUT, PATCH, DELETE, HEAD }
 
+        [Header("Identity")]
+        [Tooltip("Unique identifier for this request asset. Leave empty to auto-generate.")]
+        public string RequestId;
+
+        [Tooltip("Optional friendly name when referencing this request asset by name.")]
+        public string DisplayName;
+
         [Header("Request")]
         public MethodKind Method = MethodKind.GET;
 
@@ -50,5 +57,18 @@ namespace Flowcast.Rest.Workbench
 
         [Header("Notes (optional)")]
         [TextArea(2, 6)] public string Notes;
+
+        private void OnValidate()
+        {
+            if (string.IsNullOrWhiteSpace(RequestId))
+            {
+                RequestId = Guid.NewGuid().ToString("N");
+            }
+
+            if (string.IsNullOrEmpty(DisplayName))
+            {
+                DisplayName = name;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- create dedicated Environments and Requests folders during package initialization and rename generated environment assets to `flowcast.env.*`
- add a "Create Request Asset" action in the Flowcast package setup window to scaffold and register API request assets
- extend request assets with identity metadata and expose a lookup helper on `FlowcastRestSettings`

## Testing
- Not run (editor tooling)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910ca01ebec832d92edace466ae9a97)