### PR TITLE
Fix Unity REST transport and add Flowcast REST sample

### DIFF
--- a/Flowcast.Unity/Assets/Flowcast/Runtime/Rest/Transport/UnityWebRequestTransport.cs
+++ b/Flowcast.Unity/Assets/Flowcast/Runtime/Rest/Transport/UnityWebRequestTransport.cs
@@ -10,7 +10,10 @@ namespace Flowcast.Rest.Transport
     {
         public async Task<ApiResponse> SendAsync(ApiRequest req, CancellationToken ct)
         {
-            var uwr = new UnityWebRequest(req.Url, req.Method);
+            if (req.Url == null)
+                throw new System.ArgumentException("ApiRequest.Url must be an absolute URI", nameof(req));
+
+            var uwr = new UnityWebRequest(req.Url.AbsoluteUri, req.Method);
             if (req.TimeoutSeconds.HasValue && req.TimeoutSeconds.Value > 0)
                 uwr.timeout = req.TimeoutSeconds.Value;
 

--- a/Flowcast.Unity/Assets/Flowcast/Samples/Rest/FlowcastRestUsageSample.cs
+++ b/Flowcast.Unity/Assets/Flowcast/Samples/Rest/FlowcastRestUsageSample.cs
@@ -1,0 +1,75 @@
+using System.Threading.Tasks;
+using Flowcast.Core.Common;
+using Flowcast.Rest.Bootstrap;
+using Flowcast.Rest.Client;
+using UnityEngine;
+
+namespace Flowcast.Samples
+{
+    /// <summary>
+    /// Minimal MonoBehaviour that demonstrates how to call Flowcast.Rest once the
+    /// FlowcastRestBootstrapper has been configured in the scene.
+    /// </summary>
+    public sealed class FlowcastRestUsageSample : MonoBehaviour
+    {
+        [Header("Sample Input")]
+        [SerializeField] private string playerId = "demo";
+
+        private async void Start()
+        {
+            if (FlowcastRest.Instance == null)
+            {
+                Debug.LogWarning("[Flowcast] FlowcastRest.Instance is not configured. Add FlowcastRestBootstrapper to the scene.");
+                return;
+            }
+
+            await FetchProfileAsync();
+            await UpdateDisplayNameAsync();
+        }
+
+        private async Task FetchProfileAsync()
+        {
+            Result<PlayerProfile> result = await FlowcastRest.GetAsync<PlayerProfile>($"/v1/players/{playerId}");
+            if (result.IsSuccess)
+            {
+                Debug.Log($"[Flowcast] Player '{result.Value.displayName}' loaded.");
+            }
+            else
+            {
+                Debug.LogWarning($"[Flowcast] Failed to load player: {result.Error}");
+            }
+        }
+
+        private async Task UpdateDisplayNameAsync()
+        {
+            var payload = new UpdateDisplayNameRequest { displayName = $"Player {Random.Range(100, 999)}" };
+
+            Result<PlayerProfile> result = await FlowcastRest
+                .Send("PATCH", $"/v1/players/{playerId}")
+                .RequireAuth()
+                .WithIdempotencyKey()
+                .WithBody(payload)
+                .AsResultAsync<PlayerProfile>();
+
+            if (result.IsSuccess)
+            {
+                Debug.Log($"[Flowcast] Display name updated to '{result.Value.displayName}'.");
+            }
+            else
+            {
+                Debug.LogWarning($"[Flowcast] Failed to update player: {result.Error}");
+            }
+        }
+
+        private sealed class PlayerProfile
+        {
+            public string id;
+            public string displayName;
+        }
+
+        private sealed class UpdateDisplayNameRequest
+        {
+            public string displayName;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- guard against null request URLs and ensure UnityWebRequest is created with an absolute URI
- add a new sample MonoBehaviour that demonstrates using Flowcast.Rest helpers in a scene

## Testing
- not run (Unity project)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910ce17b094832da4d8abc2442af9b7)